### PR TITLE
Create reusable module for container service configuration

### DIFF
--- a/hosts/rofl-11/container-services.nix
+++ b/hosts/rofl-11/container-services.nix
@@ -1,132 +1,72 @@
-{
-  config,
-  lib,
-  pkgs,
-  ...
-}:
+{ config, ... }:
 
 let
-  services = {
-    jellyfin = {
-      port = 8096;
-      hosts = [
-        "tv.${config.custom.mainDomain}"
-        "jelly.${config.networking.hostName}.${config.custom.mainDomain}"
-        "jelly.${config.custom.mainDomain}"
-        "jellyfin.${config.networking.hostName}.${config.custom.mainDomain}"
-        "jellyfin.${config.custom.mainDomain}"
-        "media.${config.custom.mainDomain}"
-      ];
-    };
-    pp = {
-      port = 7827;
-      hosts = [
-        "pp.${config.custom.mainDomain}"
-      ];
-    };
-    radarr = {
-      port = 7878;
-      hosts = [
-        "rdr.${config.custom.mainDomain}"
-        "radarr.${config.custom.mainDomain}"
-        "rdr.${config.networking.hostName}.${config.custom.mainDomain}"
-        "radarr.${config.networking.hostName}.${config.custom.mainDomain}"
-      ];
-      compose_yaml = "piracy";
-    };
-    sonarr = {
-      port = 8989;
-      hosts = [
-        "snr.${config.custom.mainDomain}"
-        "sonarr.${config.custom.mainDomain}"
-        "snr.${config.networking.hostName}.${config.custom.mainDomain}"
-        "sonarr.${config.networking.hostName}.${config.custom.mainDomain}"
-      ];
-      compose_yaml = "piracy";
-    };
-    tdarr = {
-      port = 8265;
-      hosts = [
-        "tdarr.${config.custom.mainDomain}"
-        "tdarr.${config.networking.hostName}.${config.custom.mainDomain}"
-      ];
-    };
-    transmission = {
-      port = 9091;
-      hosts = [
-        "to.${config.custom.mainDomain}"
-        "to.${config.networking.hostName}.${config.custom.mainDomain}"
-      ];
+  domain = config.custom.mainDomain;
+  hostName = config.networking.hostName;
+  mkHost = subdomain: "${subdomain}.${domain}";
+  mkHostWithNode = subdomain: "${subdomain}.${hostName}.${domain}";
 
-      http_status_code = 401;
-      compose_yaml = "piracy";
-    };
-  };
+in
+{
+  imports = [
+    ../../modules/container-services.nix
+    ../../services/docker-compose-bulk.nix
+  ];
 
-  # Helper function to generate a Monit config snippet.
-  generateMonitCheck =
-    serviceName: host: service:
-    let
-      effectivePort = "443";
-      proto = "https";
-      extraClause =
-        if service ? http_status_code then "status " + toString service.http_status_code else "";
-      composePath = if service ? compose_yaml then service.compose_yaml else serviceName;
-    in
-    ''
-      check host "${serviceName}" with address "${host}"
-        group services
-        restart program = "${pkgs.docker-compose-wrapper}/bin/docker-compose-wrapper -f /srv/${composePath}/docker-compose.yaml up -d --force-recreate --always-recreate-deps ${serviceName}"
-        if failed
-          port ${effectivePort}
-          protocol ${proto} ${extraClause}
-          with timeout 90 seconds
-        then restart
-        if 5 restarts within 10 cycles then alert
-    '';
-
-  # Generate a config snippet for each service using its service name and main host.
-  generatedChecks = lib.mapAttrs (
-    serviceName: service:
-    let
-      firstHost = builtins.head service.hosts;
-    in
-    generateMonitCheck serviceName firstHost service
-  ) services;
-
-  monitExtraConfig = lib.concatStringsSep "\n\n" (lib.attrValues generatedChecks);
-
-  # Helper function to create virtual hosts for each service
-  createVirtualHost = service: hostname: {
-    name = hostname;
-    value = {
-      default = service.default or false;
-      enableACME = true;
-      # FIXME https://github.com/NixOS/nixpkgs/issues/210807
-      acmeRoot = null;
-      forceSSL = true;
-      locations."/" = {
-        proxyPass = "http${if service.tls or false then "s" else ""}://127.0.0.1:${toString service.port}";
-        proxyWebsockets = true;
-        recommendedProxySettings = true;
+  custom.containerServices = {
+    enable = true;
+    services = {
+      jellyfin = {
+        port = 8096;
+        hosts = [
+          (mkHost "tv")
+          (mkHostWithNode "jelly")
+          (mkHost "jelly")
+          (mkHostWithNode "jellyfin")
+          (mkHost "jellyfin")
+          (mkHost "media")
+        ];
+      };
+      pp = {
+        port = 7827;
+        hosts = [ (mkHost "pp") ];
+      };
+      radarr = {
+        port = 7878;
+        hosts = [
+          (mkHost "rdr")
+          (mkHost "radarr")
+          (mkHostWithNode "rdr")
+          (mkHostWithNode "radarr")
+        ];
+        compose_yaml = "piracy";
+      };
+      sonarr = {
+        port = 8989;
+        hosts = [
+          (mkHost "snr")
+          (mkHost "sonarr")
+          (mkHostWithNode "snr")
+          (mkHostWithNode "sonarr")
+        ];
+        compose_yaml = "piracy";
+      };
+      tdarr = {
+        port = 8265;
+        hosts = [
+          (mkHost "tdarr")
+          (mkHostWithNode "tdarr")
+        ];
+      };
+      transmission = {
+        port = 9091;
+        hosts = [
+          (mkHost "to")
+          (mkHostWithNode "to")
+        ];
+        http_status_code = 401;
+        compose_yaml = "piracy";
       };
     };
   };
-
-  # Generate virtual hosts for all services and their hostnames
-  virtualHosts = builtins.listToAttrs (
-    lib.concatMap (
-      serviceName:
-      let
-        service = services.${serviceName};
-      in
-      map (hostname: createVirtualHost service hostname) service.hosts
-    ) (builtins.attrNames services)
-  );
-in
-{
-  imports = [ ../../services/docker-compose-bulk.nix ];
-
-  services.nginx.virtualHosts = virtualHosts;
-  services.monit.config = lib.mkAfter monitExtraConfig;
 }

--- a/modules/container-services.nix
+++ b/modules/container-services.nix
@@ -1,0 +1,185 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    types
+    mapAttrs
+    concatMap
+    attrValues
+    concatStringsSep
+    attrNames
+    optionalString
+  ;
+
+  cfg = config.custom.containerServices;
+
+  serviceType = types.submodule (_: {
+    options = {
+      port = mkOption {
+        type = types.port;
+        description = "Internal port exposed by the container.";
+      };
+
+      hosts = mkOption {
+        type = types.listOf types.str;
+        description = "Hostnames that should route to the container.";
+      };
+
+      default = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether this virtual host should be the default server.";
+      };
+
+      tls = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether the container expects TLS at the upstream.";
+      };
+
+      http_status_code = mkOption {
+        type = types.nullOr types.int;
+        default = null;
+        description = "Optional expected HTTP status code for health checks.";
+      };
+
+      compose_yaml = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Optional docker-compose project directory.";
+      };
+
+      enableACME = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = "Override the ACME enablement for this virtual host.";
+      };
+
+      useACMEHost = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Override the ACME certificate to reuse for this host.";
+      };
+    };
+  });
+
+  effectiveEnableACME = service:
+    let
+      override = service.enableACME;
+      base =
+        if service.default then cfg.defaultEnableACMEForDefaultHosts else cfg.defaultEnableACME;
+    in
+    if override != null then override else base;
+
+  effectiveUseACMEHost = service:
+    let
+      override = service.useACMEHost;
+      base =
+        if service.default
+        then cfg.defaultUseACMEHostForDefaultHosts
+        else cfg.defaultUseACMEHost;
+    in
+    if override != null then override else base;
+
+  generateMonitCheck = serviceName: host: service:
+    let
+      effectivePort = "443";
+      proto = "https";
+      extraClause =
+        if service.http_status_code != null then "status " + toString service.http_status_code else "";
+      composePath =
+        if service.compose_yaml != null then service.compose_yaml else serviceName;
+    in
+    ''
+      check host "${serviceName}" with address "${host}"
+        group services
+        restart program = "${pkgs.docker-compose-wrapper}/bin/docker-compose-wrapper -f /srv/${composePath}/docker-compose.yaml up -d --force-recreate --always-recreate-deps ${serviceName}"
+        if failed
+          port ${effectivePort}
+          protocol ${proto}${optionalString (extraClause != "") " ${extraClause}"}
+          with timeout 90 seconds
+        then restart
+        if 5 restarts within 10 cycles then alert
+    '';
+
+  generatedChecks = mapAttrs (
+    serviceName: service:
+      let
+        firstHost = builtins.head service.hosts;
+      in
+      generateMonitCheck serviceName firstHost service
+  ) cfg.services;
+
+  monitExtraConfig = concatStringsSep "\n\n" (attrValues generatedChecks);
+
+  createVirtualHost = service: hostname: {
+    name = hostname;
+    value = {
+      default = service.default;
+      enableACME = effectiveEnableACME service;
+      useACMEHost = effectiveUseACMEHost service;
+      # FIXME https://github.com/NixOS/nixpkgs/issues/210807
+      acmeRoot = null;
+      forceSSL = true;
+      locations."/" = {
+        proxyPass = "http${if service.tls then "s" else ""}://127.0.0.1:${toString service.port}";
+        proxyWebsockets = true;
+        recommendedProxySettings = true;
+      };
+    };
+  };
+
+  virtualHosts = builtins.listToAttrs (
+    concatMap (
+      serviceName:
+        let
+          service = cfg.services.${serviceName};
+        in
+        map (hostname: createVirtualHost service hostname) service.hosts
+    ) (attrNames cfg.services)
+  );
+
+in
+{
+  options.custom.containerServices = {
+    enable = mkEnableOption "automatic container virtual host and Monit configuration";
+
+    services = mkOption {
+      type = types.attrsOf serviceType;
+      default = {};
+      description = "Container services exposed through nginx and monitored by Monit.";
+    };
+
+    defaultEnableACME = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Default ACME enablement for non-default virtual hosts.";
+    };
+
+    defaultEnableACMEForDefaultHosts = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Default ACME enablement for virtual hosts marked as default.";
+    };
+
+    defaultUseACMEHost = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Default ACME certificate name to reuse for non-default hosts.";
+    };
+
+    defaultUseACMEHostForDefaultHosts = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Default ACME certificate name to reuse for default hosts.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.nginx.virtualHosts = virtualHosts;
+    services.monit.config = lib.mkAfter monitExtraConfig;
+  };
+}


### PR DESCRIPTION
## Summary
- extract common container service and monitoring logic into a reusable module
- switch rofl-10 and rofl-11 to the shared container services module and keep host-specific settings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da549b56d08323879f89d632696781