### PR TITLE
Reuse shared HTTP module for oci-03 mmonit configuration

### DIFF
--- a/hosts/oci-03/default.nix
+++ b/hosts/oci-03/default.nix
@@ -7,6 +7,7 @@
     ../../server/oci.nix
 
     ../../server/mmonit.nix
+    ../../services/http.nix
     ../../services/parsedmarc.nix
     ../../common/restic
 

--- a/server/mmonit.nix
+++ b/server/mmonit.nix
@@ -29,44 +29,25 @@
     config.services.restic.backups.main.paths ++ [ "/var/lib/mmonit" ]
   );
 
-  services.nginx = {
-    enable = true;
-    recommendedGzipSettings = true;
-    recommendedOptimisation = true;
-    recommendedProxySettings = true;
-    recommendedTlsSettings = true;
+  services.nginx.virtualHosts =
+    let
+      commonConfig = {
+        enableACME = true;
+        forceSSL = true;
 
-    virtualHosts =
-      let
-        commonConfig = {
-          # NOTE we do HTTP-01 here!
-          enableACME = true;
-          forceSSL = true;
-
-          locations."/" = {
-            proxyPass = "http://127.0.0.1:8080/";
-            index = "index.csp";
-            proxyWebsockets = true;
-            extraConfig = ''
-              # Avoid redirections to the wrong port (ie. 8080)
-              proxy_set_header X-Forwarded-Port $server_port;
-            '';
-          };
+        locations."/" = {
+          proxyPass = "http://127.0.0.1:8080/";
+          index = "index.csp";
+          proxyWebsockets = true;
+          extraConfig = ''
+            # Avoid redirections to the wrong port (ie. 8080)
+            proxy_set_header X-Forwarded-Port $server_port;
+          '';
         };
-      in
-      {
-        "mmonit.${config.networking.hostName}.${config.custom.mainDomain}" = commonConfig;
-        "mmonit.${config.custom.mainDomain}" = commonConfig;
       };
-  };
-
-  networking.firewall.allowedTCPPorts = [
-    80
-    443
-  ];
-
-  security.acme = {
-    acceptTerms = true;
-    defaults.email = config.custom.email;
-  };
+    in
+    {
+      "mmonit.${config.networking.hostName}.${config.custom.mainDomain}" = commonConfig;
+      "mmonit.${config.custom.mainDomain}" = commonConfig;
+    };
 }


### PR DESCRIPTION
## Summary
- add the shared HTTP service module to the oci-03 host
- simplify the mmonit module to rely on the shared HTTP configuration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df777f06e88323ac2aed33fca067b4