### PR TITLE
chore: update jsonrepair from 3.13.xx to 3.14.xx

### DIFF
--- a/pkgs/jsonrepair/default.nix
+++ b/pkgs/jsonrepair/default.nix
@@ -6,16 +6,16 @@
 
 buildNpmPackage rec {
   pname = "jsonrepair";
-  version = "3.13.3";
+  version = "3.14.0";
 
   src = fetchFromGitHub {
     owner = "josdejong";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-hJTM4bDdjQ0OI8Rymc2VNQuOxpslhAIe+EqfptFmpWw=";
+    hash = "sha256-laA7bU47P6ZzFkO2ubheSYIlMs07Gh3ZtBC2emXlz1M=";
   };
 
-  npmDepsHash = "sha256-LmyT/7CocVMK3VEkSzAP6lhqMZVcJBk2vquvnFHbVXw=";
+  npmDepsHash = "sha256-2KyONy6GUatO9sw1Yq1hYbQx6gNnZxVBkYPnp35aTT0=";
 
   # The prepack script runs the build script, which we'd rather do in the build phase.
   # npmPackFlags = [ "--ignore-scripts" ];


### PR DESCRIPTION
Automated nix-update for `jsonrepair` on x86_64-linux and aarch64-linux.
Generated by `.github/workflows/nix-update.yaml`.