### PR TITLE
chore: update go-hass-agent from 14.10.xx to 14.10.xx

### DIFF
--- a/pkgs/go-hass-agent/default.nix
+++ b/pkgs/go-hass-agent/default.nix
@@ -10,16 +10,16 @@
 
 buildGoModule rec {
   pname = "go-hass-agent";
-  version = "14.10.3";
+  version = "14.10.5";
 
   src = pkgs.fetchFromGitHub {
     owner = "joshuar";
     repo = "go-hass-agent";
     rev = "v${version}";
-    hash = "sha256-7F4zxxMKNrUiKonfO7dQQuODEnFgaFRM7Rzb7n1Erys=";
+    hash = "sha256-jBcXHXsJUBRGt2Nvnx3vUCIHx+pUBa+aBLhN6m8KY98=";
   };
 
-  vendorHash = "sha256-WPglpc8xqCW51LmdhGLAuB4jg96T72eRuaS61zagoNw=";
+  vendorHash = "sha256-nmlkHfwO1VPrszvUDskRwaxh4DYDMoBYhLXMmzqmXq4=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
Automated nix-update for `go-hass-agent` on x86_64-linux and aarch64-linux.
Generated by `.github/workflows/nix-update.yaml`.