### PR TITLE
chore: update oracle-cloud-agent from 1.57.xx to 1.58.xx

### DIFF
--- a/pkgs/oci/oracle-cloud-agent/sources.json
+++ b/pkgs/oci/oracle-cloud-agent/sources.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.57.0",
-  "release": "2.el9",
-  "hashAarch64": "sha256-P3U031ze7zjLsLS9s+l3o4gj8WRkrURMKeX5vSpll3c=",
-  "hashX86_64": "sha256-U2O9E1QmuZz4bfZv7mEmZzHlu+1rlS7DWoHbzdOYNYk="
+  "version": "1.58.0",
+  "release": "10.el9",
+  "hashAarch64": "sha256-kNzf4yuZMu9JJ+gz/efPJu+yCZ6f89sAGdUoFyX47hk=",
+  "hashX86_64": "sha256-YLVAem9j/Tf4bhsy/JHUjkCTOEYVE2ZzolPeoA6p4UU="
 }


### PR DESCRIPTION
Automated nix-update for `oracle-cloud-agent` on x86_64-linux and aarch64-linux.
Generated by `.github/workflows/nix-update.yaml`.