### PR TITLE
chore: update tmux-mcp from 0.2.xx to 0.3.xx

### DIFF
--- a/pkgs/tmux-mcp/default.nix
+++ b/pkgs/tmux-mcp/default.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tmux-mcp-rs";
-  version = "0.2.1";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "bnomei";
     repo = "tmux-mcp";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-YT0yvTC2iM2j0ckEP+7PfLNjRJmP9Dt7T0P/Ufp2Wv4=";
+    hash = "sha256-Umnh1YXPonbtnlQyJex9tuVXJVIeGRd/FVHMUxiDk1s=";
   };
 
-  cargoHash = "sha256-MZV/yuTMOdsOQqjdNflaIJSJzgQ3KXAo5xgnesmltoE=";
+  cargoHash = "sha256-YiEstaMUNwuaRR3bTjjQ2Ew/txhwNoa0POfhplYUkhI=";
 
   meta = {
     description = "MCP server for tmux — lets AI assistants create sessions, split panes, run commands, and capture output";


### PR DESCRIPTION
Automated nix-update for `tmux-mcp` on x86_64-linux and aarch64-linux.
Generated by `.github/workflows/nix-update.yaml`.