### PR TITLE
chore: update tmux-mcp from 0.3.xx to 0.4.xx

### DIFF
--- a/pkgs/tmux-mcp/default.nix
+++ b/pkgs/tmux-mcp/default.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tmux-mcp-rs";
-  version = "0.3.0";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "bnomei";
     repo = "tmux-mcp";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-Umnh1YXPonbtnlQyJex9tuVXJVIeGRd/FVHMUxiDk1s=";
+    hash = "sha256-s4LiTjgdDUUzpTlql+ajydYb7Psg/G04fKjaGeBoGlY=";
   };
 
-  cargoHash = "sha256-YiEstaMUNwuaRR3bTjjQ2Ew/txhwNoa0POfhplYUkhI=";
+  cargoHash = "sha256-SFsYPyzeMlrIvulZjuXudHOF5qcf1M39W1ZZvkqgvYg=";
 
   meta = {
     description = "MCP server for tmux — lets AI assistants create sessions, split panes, run commands, and capture output";


### PR DESCRIPTION
Automated nix-update for `tmux-mcp` on x86_64-linux and aarch64-linux.
Generated by `.github/workflows/nix-update.yaml`.