### PR TITLE
chore: update lnxlink from 2026.2.xx to 2026.6.xx

### DIFF
--- a/pkgs/lnxlink/default.nix
+++ b/pkgs/lnxlink/default.nix
@@ -17,13 +17,13 @@
 
 buildPythonApplication rec {
   pname = "lnxlink";
-  version = "2026.2.0";
+  version = "2026.6.0";
 
   src = fetchFromGitHub {
     owner = "bkbilly";
     repo = "lnxlink";
     rev = version;
-    hash = "sha256-PyonUBCeEiXQWsW9v5F3XiQE30xPOkRJTNmtaktg0Sw=";
+    hash = "sha256-FdAeEUwVQ4L6bl6x3SpHwo85uy/xPv4wU0NWpimaU/c=";
   };
 
   pyproject = true;


### PR DESCRIPTION
Automated nix-update for `lnxlink` on x86_64-linux and aarch64-linux.
Generated by `.github/workflows/nix-update.yaml`.