### PR TITLE
chore: update tewi from 2.4.xx to 2.4.xx

### DIFF
--- a/pkgs/tewi/default.nix
+++ b/pkgs/tewi/default.nix
@@ -27,14 +27,14 @@ let
 in
 python3.pkgs.buildPythonApplication rec {
   pname = "tewi";
-  version = "2.4.0";
+  version = "2.4.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "anlar";
     repo = "tewi";
     rev = "v${version}";
-    hash = "sha256-FDzZzUAlgmKP5dhL9SsAhKY/z/PYu/4uE9hEmYqd9i4=";
+    hash = "sha256-EpjqUcbxX7bWsCf3kbm421ELmzmfEXbTbKQ63Qrs4Yg=";
   };
 
   build-system = [


### PR DESCRIPTION
Automated nix-update for `tewi` on x86_64-linux and aarch64-linux.
Generated by `.github/workflows/nix-update.yaml`.