### PR TITLE
chore: update jsonrepair from 3.14.xx to 3.15.xx

### DIFF
--- a/pkgs/jsonrepair/default.nix
+++ b/pkgs/jsonrepair/default.nix
@@ -6,16 +6,16 @@
 
 buildNpmPackage rec {
   pname = "jsonrepair";
-  version = "3.14.1";
+  version = "3.15.0";
 
   src = fetchFromGitHub {
     owner = "josdejong";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-jP9mOS6m5gP3uIQatui01jeIi1kLFZiZh/eCzr/tSgI=";
+    hash = "sha256-tVqq/wBh1gf4F44DKc5A55E2akpeiMalZUk+8mH1+ZQ=";
   };
 
-  npmDepsHash = "sha256-dhEmxiA9pYqFBbTbtvxM618bUiVW9Xrr9etErz58S70=";
+  npmDepsHash = "sha256-475pna349LoS+ZorlTNTA/XKZ49Sl3BYSo4h0gg2dTc=";
 
   # The prepack script runs the build script, which we'd rather do in the build phase.
   # npmPackFlags = [ "--ignore-scripts" ];


### PR DESCRIPTION
Automated nix-update for `jsonrepair` on x86_64-linux and aarch64-linux.
Generated by `.github/workflows/nix-update.yaml`.