### PR TITLE
chore: update tmux-mcp from 0.5.xx to 0.6.xx

### DIFF
--- a/pkgs/tmux-mcp/default.nix
+++ b/pkgs/tmux-mcp/default.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tmux-mcp-rs";
-  version = "0.5.0";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "bnomei";
     repo = "tmux-mcp";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-PYME5/FW/87QrufAM3KD4AlJCut4PSImfBVp7L5aw/g=";
+    hash = "sha256-iB9fn6mn48f/cW/TWHIi1rhbw7eYEv5+ccMSUFljMlo=";
   };
 
-  cargoHash = "sha256-+XHzCGJYrIoiajQ3VkmfIeWNMCaebZT0WJ8qVKwHXkE=";
+  cargoHash = "sha256-wNzYDsk2r5O/BCOe9Zwj/PlHVUwm9JieLyX2M503hyc=";
 
   meta = {
     description = "MCP server for tmux — lets AI assistants create sessions, split panes, run commands, and capture output";


### PR DESCRIPTION
Automated nix-update for `tmux-mcp` on x86_64-linux and aarch64-linux.
Generated by `.github/workflows/nix-update.yaml`.