### PR TITLE
chore: update withoutbg from 1.1.xx to 1.1.xx

### DIFF
--- a/pkgs/withoutbg/default.nix
+++ b/pkgs/withoutbg/default.nix
@@ -27,13 +27,13 @@ let
 in
 buildPythonApplication rec {
   pname = "withoutbg";
-  version = "1.1.0";
+  version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "withoutbg";
     repo = "withoutbg";
     rev = "v${version}";
-    hash = "sha256-I2SKwsiMR8UaRE7dEW267dEXs9zq6KgQbqGkGIpBoOQ=";
+    hash = "sha256-91dt31Yhixx7mcHws7R6BB3wpOz9vFG7OvJiLS6kLFs=";
   };
 
   pyproject = true;


### PR DESCRIPTION
Automated nix-update for `withoutbg` on x86_64-linux and aarch64-linux.
Generated by `.github/workflows/nix-update.yaml`.