### PR TITLE
chore: update native-client from 1.0.xx to 1.1.xx

### DIFF
--- a/pkgs/native-client/default.nix
+++ b/pkgs/native-client/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "native-client";
-  version = "1.0.8";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "andy-portmen";
     repo = "native-client";
     rev = "v${version}";
-    hash = "sha256-/Zr5FSfZ5Sh1kE/x0wF0Uljg0mnE0QkO6etgopaIXmo=";
+    hash = "sha256-zqjorORcbLH5DGoalFM31DAbDqhZw/C/oRFHA0zDKMc=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Automated nix-update for `native-client` on x86_64-linux and aarch64-linux.
Generated by `.github/workflows/nix-update.yaml`.