### PR TITLE
flake: pin hyprgrass for Hyprland 0.56

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1359,16 +1359,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1784737492,
-        "narHash": "sha256-r0kKcEid5NcolUgfE7rI1TT3VAMxrnjqzGLIVs/lbI8=",
+        "lastModified": 1783294439,
+        "narHash": "sha256-fb3yy/VSBpnUScFFWZNhF+5sH+EVgvhYbmJYIWGRrig=",
         "owner": "horriblename",
         "repo": "hyprgrass",
-        "rev": "36df29f57f94a77b4d5dcf91100f620a46663fa9",
+        "rev": "e28346f49144e058b0e2d9dc66313c0a57c3d423",
         "type": "github"
       },
       "original": {
         "owner": "horriblename",
         "repo": "hyprgrass",
+        "rev": "e28346f49144e058b0e2d9dc66313c0a57c3d423",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -144,7 +144,9 @@
     };
 
     hyprgrass = {
-      url = "github:horriblename/hyprgrass";
+      # The latest revisions changed GestureManager.cpp beyond the local
+      # Hyprland 0.56 compatibility patch; keep the last known-good commit.
+      url = "github:horriblename/hyprgrass/e28346f49144e058b0e2d9dc66313c0a57c3d423";
       inputs.hyprland.follows = "hyprland"; # IMPORTANT
     };
 


### PR DESCRIPTION
Pins Hyprgrass to the last known-good revision for Hyprland 0.56.

The latest input revision changed `GestureManager.cpp`, so the local API-compatibility patch no longer applied. The `private` submodule pointer is also updated to its current `main` revision.

Validated with `nix build '.#nixosConfigurations.ge2.pkgs.hyprgrass' --no-link --fallback`, `nix develop -c statix check`, and pre-commit hooks.