### PR TITLE
chore: update immich-face-to-album from 1.0.xx to 1.0.xx

### DIFF
--- a/pkgs/immich-face-to-album/default.nix
+++ b/pkgs/immich-face-to-album/default.nix
@@ -6,13 +6,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "immich-face-to-album";
-  version = "1.0.14";
+  version = "1.0.16";
   pyproject = true;
 
   src = fetchPypi {
     pname = "immich_face_to_album";
     inherit version;
-    hash = "sha256-gxXFqPgXD0CYiqx3di5MCxguYTZVEEih+BM5cIBZwNc=";
+    hash = "sha256-D6Fbll/hrSDJq/YmR1zEYtkDLHgS2JgSIPm91qaYRGs=";
   };
 
   build-system = [


### PR DESCRIPTION
Automated nix-update for `immich-face-to-album` on x86_64-linux and aarch64-linux.
Generated by `.github/workflows/nix-update.yaml`.