### PR TITLE
chore: update tewi from 2.4.xx to 2.5.xx

### DIFF
--- a/pkgs/tewi/default.nix
+++ b/pkgs/tewi/default.nix
@@ -27,14 +27,14 @@ let
 in
 python3.pkgs.buildPythonApplication rec {
   pname = "tewi";
-  version = "2.4.1";
+  version = "2.5.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "anlar";
     repo = "tewi";
     rev = "v${version}";
-    hash = "sha256-EpjqUcbxX7bWsCf3kbm421ELmzmfEXbTbKQ63Qrs4Yg=";
+    hash = "sha256-d6s0zaWIHNxo6vPengdZ766w/BE8cPnhfbkbs70Vpuk=";
   };
 
   build-system = [


### PR DESCRIPTION
Automated nix-update for `tewi` on x86_64-linux and aarch64-linux.
Generated by `.github/workflows/nix-update.yaml`.