### PR TITLE
Deploy Hermes Agent on rofl-10

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -491,6 +491,27 @@
     "flake-parts_2": {
       "inputs": {
         "nixpkgs-lib": [
+          "hermes-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": [
           "llm-agents",
           "nixpkgs"
         ]
@@ -509,7 +530,7 @@
         "type": "github"
       }
     },
-    "flake-parts_3": {
+    "flake-parts_4": {
       "inputs": {
         "nixpkgs-lib": [
           "neovim-nightly",
@@ -530,7 +551,7 @@
         "type": "github"
       }
     },
-    "flake-parts_4": {
+    "flake-parts_5": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib_3"
       },
@@ -548,7 +569,7 @@
         "type": "github"
       }
     },
-    "flake-parts_5": {
+    "flake-parts_6": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib_4"
       },
@@ -1153,6 +1174,31 @@
         "owner": "harfbuzz",
         "ref": "11.2.1",
         "repo": "harfbuzz",
+        "type": "github"
+      }
+    },
+    "hermes-agent": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "npm-lockfile-fix": "npm-lockfile-fix",
+        "pyproject-build-systems": "pyproject-build-systems",
+        "pyproject-nix": "pyproject-nix",
+        "uv2nix": "uv2nix"
+      },
+      "locked": {
+        "lastModified": 1785221911,
+        "narHash": "sha256-YFJLWSbPzyPs6oRXdMm8GR9RPR71Q417IOD4/psJ7Z0=",
+        "owner": "NousResearch",
+        "repo": "hermes-agent",
+        "rev": "4da7b9ee029c6ece2eb7992fc27dbcd086982c84",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NousResearch",
+        "repo": "hermes-agent",
         "type": "github"
       }
     },
@@ -2017,7 +2063,7 @@
     "llm-agents": {
       "inputs": {
         "bun2nix": "bun2nix",
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts_3",
         "nixpkgs": "nixpkgs_5",
         "systems": "systems_12",
         "treefmt-nix": "treefmt-nix"
@@ -2234,7 +2280,7 @@
     },
     "neovim-nightly": {
       "inputs": {
-        "flake-parts": "flake-parts_3",
+        "flake-parts": "flake-parts_4",
         "neovim-src": "neovim-src",
         "nixpkgs": [
           "nixpkgs"
@@ -2844,6 +2890,27 @@
         "type": "gitlab"
       }
     },
+    "npm-lockfile-fix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775903712,
+        "narHash": "sha256-2GV79U6iVH4gKAPWYrxUReB0S41ty/Y3dBLquU8AlaA=",
+        "owner": "jeslie0",
+        "repo": "npm-lockfile-fix",
+        "rev": "c6093acb0c0548e0f9b8b3d82918823721930fe8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jeslie0",
+        "repo": "npm-lockfile-fix",
+        "type": "github"
+      }
+    },
     "obs-cli": {
       "inputs": {
         "flake-utils": "flake-utils_14",
@@ -2867,7 +2934,7 @@
     },
     "poor-tools": {
       "inputs": {
-        "flake-parts": "flake-parts_4",
+        "flake-parts": "flake-parts_5",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -3037,6 +3104,56 @@
         "type": "github"
       }
     },
+    "pyproject-build-systems": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "hermes-agent",
+          "pyproject-nix"
+        ],
+        "uv2nix": [
+          "hermes-agent",
+          "uv2nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772555609,
+        "narHash": "sha256-3BA3HnUvJSbHJAlJj6XSy0Jmu7RyP2gyB/0fL7XuEDo=",
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "rev": "c37f66a953535c394244888598947679af231863",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772865871,
+        "narHash": "sha256-/ZTSg97aouL0SlPHaokA4r3iuH9QzHVuWPACD2CUCFY=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "e537db02e72d553cea470976b9733581bcf5b3ed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
     "qmd": {
       "inputs": {
         "flake-utils": [
@@ -3102,6 +3219,7 @@
         "ghostty": "ghostty",
         "grim-hyprland": "grim-hyprland",
         "hardware": "hardware",
+        "hermes-agent": "hermes-agent",
         "home-manager": "home-manager_2",
         "hypr-dynamic-cursors": "hypr-dynamic-cursors",
         "hyprgrass": "hyprgrass",
@@ -3949,7 +4067,7 @@
     "update-systemd-resolved": {
       "inputs": {
         "devshell": "devshell",
-        "flake-parts": "flake-parts_5",
+        "flake-parts": "flake-parts_6",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -3966,6 +4084,31 @@
       "original": {
         "owner": "jonathanio",
         "repo": "update-systemd-resolved",
+        "type": "github"
+      }
+    },
+    "uv2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "hermes-agent",
+          "pyproject-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773039484,
+        "narHash": "sha256-+boo33KYkJDw9KItpeEXXv8+65f7hHv/earxpcyzQ0I=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "b68be7cfeacbed9a3fa38a2b5adc0cfb81d9bb1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -108,6 +108,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    hermes-agent = {
+      url = "github:NousResearch/hermes-agent";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     nix-on-droid = {
       url = "github:nix-community/nix-on-droid";
       inputs.home-manager.follows = "home-manager";

--- a/hosts/rofl-10/default.nix
+++ b/hosts/rofl-10/default.nix
@@ -27,6 +27,7 @@
     ../../services/gitea-mirror.nix
     ../../services/github-backup.nix
     ../../services/harmonia.nix
+    ../../services/hermes.nix
     ../../services/http-static.nix
     ../../services/http.nix
     ../../services/immich.nix

--- a/hosts/rofl-10/secrets.sops.yaml
+++ b/hosts/rofl-10/secrets.sops.yaml
@@ -140,6 +140,9 @@ netbox:
     apiTokenPeppers: ENC[AES256_GCM,data:ZsM0dqNALWnq7E0k45+ZJDbEjhEqPMAL9KpN0YJoOl2SY7e38UoonZ+lEdruAVbm9DI=,iv:eABC/PBl9tCKIqJai4F1t+R5t75mqns2al/O126D648=,tag:WxrcLYXepMG0WJjJKvP6/Q==,type:str]
 endurain-ingest:
     env: ENC[AES256_GCM,data:HYZmBoUwdmenw+rN3EsMtD3TZr7NWj971am22eP/DCc51BjqvSvuUxoWjppfdt/XaZDTd8WEUxOAYgwIcHKcKxQyHbI4Ev8OONizGlmBLR12d5NHKQ==,iv:r9DWvhzKx9sIZzQCiZxa6ZZ5Le6gT3ySZiG73SXEky4=,tag:4lU6bgkF2gpzxc+NnFKqhw==,type:str]
+hermes:
+    home-assistant:
+        llat: ENC[AES256_GCM,data:35zxi6ACrcEmRUAvW5VrOCSy+zGlvAzl9ypfKLeoeRbeSkVV9m2sk8/PY17SHHOfutvzBu/+ImLhE0jEM8GOZ0IgSWp3nGOvnzw7i9VpObLT8dkiBnNXaEc+FFcbMBQ1rZsQxjuJj7nKm8WEIJRllLx0VLHo25sN8Pm/McEPadsYBJjhA7ip0cWPGQ/SFWwsG3NIgjrRKuZmShovhX+EcTkkVWQR0W4MODov7SW5DLjal6zkVzM9,iv:Q7MzZx90poppZVhm+8HOSM7um4HqabAjD/yihCELCYw=,tag:E12S2cNg6pFjpmy5hm791Q==,type:str]
 sops:
     age:
         - enc: |
@@ -214,7 +217,7 @@ sops:
             Uh8fgzd712/iMsOsoAICqK9la0UR0+3kkHYsLPJ8HoY/G9LavrVQDw==
             -----END AGE ENCRYPTED FILE-----
           recipient: age12uccn3k687ydk5jpmjwh3yp637x7rgy0tsx820t2rg70y7qdxuhqc6madk
-    lastmodified: "2026-06-22T09:48:53Z"
-    mac: ENC[AES256_GCM,data:4SmL1kIc/Ho1LRjS5UodzNOULEZ/fz5MVklgZg87+zoUuJWQd/3HuWzIDwzyeBRl8Ek/oWW7uWs2EPzNi61mwgdkkAQi6X+6GLi+HMoC/yiFNhy9y9nHvQs/QiATd8hqIGYAB81R8jTIBoyEyPzPjoM4zCgPLQzaFegHllnZq9k=,iv:xu6Fib7gPZd6ELJ9kSznjaYx0OO0OeSJ/WV7eCJv7J0=,tag:Jj4TCvrTsluGRkD/l+Srnw==,type:str]
+    lastmodified: "2026-07-28T09:24:32Z"
+    mac: ENC[AES256_GCM,data:LUpYAc34zxrmLgl9UAfbJrNCTNNSfoHfqukblAVQKLD7rVDxF6fdzmDLzo8SVTH59j7r1r3syPXTTEM57fFCQEnYDRIUyqDfe0JiFRHPh2Z/Lf1VGmGGpz759ii3vWu7gRb/ku6kDjRksJUrdHmut0fn6IA70oYK8IZEE/uuuII=,iv:LejWGSB++9SgtowBEnpNn7YkNZYsmDx8xG/XkrUKyjE=,tag:otG1YxMcdXou3SVNailIfQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.1

--- a/services/authelia.nix
+++ b/services/authelia.nix
@@ -70,6 +70,13 @@ let
           domain = [ autheliaDomain ];
         }
       ]
+      ++ lib.optional (config.custom.authelia.extraTwoFactorDomains != [ ]) {
+        # Like extraAuthenticatedDomains, but require the stronger policy for
+        # applications whose control plane can execute privileged actions.
+        # This precedes the mesh-wide bypass below.
+        policy = "two_factor";
+        domain = config.custom.authelia.extraTwoFactorDomains;
+      }
       ++ lib.optional (config.custom.authelia.extraAuthenticatedDomains != [ ]) {
         # Some apps have NO login of their own — they use proxy auth (e.g.
         # X-Auth-User from Authelia's Remote-User) or run with
@@ -122,6 +129,16 @@ in
         would leave them reachable unauthenticated from anywhere on the mesh.
         Populated by same-host modules (e.g. a private flake input's per-host
         file), same caveat as extraAccessControlRules above.
+      '';
+    };
+
+    extraTwoFactorDomains = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        Domains that must require two-factor authentication even on the mesh,
+        for sensitive control-plane applications. These rules are placed before
+        the mesh-wide bypass.
       '';
     };
   };

--- a/services/hermes.nix
+++ b/services/hermes.nix
@@ -1,0 +1,204 @@
+{
+  config,
+  inputs,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  hermesHost = "hermes.${config.domains.main}";
+  aiHost = "ai.${config.domains.main}";
+  dashboardPort = 9119;
+  autheliaConfig = import ./authelia-nginx-config.nix { inherit config; };
+
+  # Keep Hermes' skill library in the Nix store. Hermes treats external skill
+  # directories as read-only and discovers the agentskills.io-compatible
+  # SKILL.md files from this path.
+  n8nSkillsSrc = pkgs.fetchFromGitHub {
+    owner = "czlonkowski";
+    repo = "n8n-skills";
+    rev = "27e9d0ab92cccfc46db4f147497b173f214b69c5";
+    hash = "sha256-D8wEZblUGWfXKIxw3TYXhZZ0P4C1lf71cSAVgjOpmes=";
+  };
+  hermesSkills = pkgs.symlinkJoin {
+    name = "hermes-skills";
+    paths = [
+      ../home-manager/devel/skills
+      "${n8nSkillsSrc}/skills"
+      pkgs.todoist-cli.skill
+    ];
+  };
+in
+{
+  imports = [
+    inputs.hermes-agent.nixosModules.default
+  ];
+
+  sops = {
+    # The existing MCP tokens stay encrypted at rest and are exposed to the
+    # gateway only through a root-owned systemd environment file.
+    secrets = {
+      "n8n/mcp/token" = {
+        sopsFile = ../secrets/shared.sops.yaml;
+        mode = "0400";
+      };
+      "home-assistant/mcp/token" = {
+        sopsFile = ../secrets/shared.sops.yaml;
+        mode = "0400";
+      };
+      "hermes/home-assistant/llat" = config.custom.mkSecret {
+        mode = "0400";
+      };
+    };
+    templates."hermes/mcp.env" = {
+      content = ''
+        MCP_N8N_API_KEY=${config.sops.placeholder."n8n/mcp/token"}
+        MCP_HOME_ASSISTANT_API_KEY=${config.sops.placeholder."home-assistant/mcp/token"}
+        HASS_URL=https://ha.${config.domains.main}
+        HASS_TOKEN=${config.sops.placeholder."hermes/home-assistant/llat"}
+      '';
+      mode = "0400";
+      restartUnits = [ "hermes-agent.service" ];
+    };
+  };
+
+  services = {
+    hermes-agent = {
+      enable = true;
+      addToSystemPackages = true;
+      stateDir = "/srv/hermes";
+      workingDirectory = "/srv/hermes/workspace";
+      settings = {
+        model = {
+          provider = "openai-codex";
+          default = "gpt-5.6-luna";
+        };
+        tool_loop_guardrails = {
+          hard_stop_enabled = true;
+          hard_stop_after = {
+            exact_failure = 5;
+            idempotent_no_progress = 5;
+          };
+        };
+        mcp_servers = {
+          n8n = {
+            url = "https://n8n.${config.domains.main}/mcp-server/http";
+            headers.Authorization = "Bearer \${MCP_N8N_API_KEY}";
+            connect_timeout = 30;
+            timeout = 90;
+          };
+          home-assistant = {
+            url = "https://ha.${config.domains.main}/api/mcp";
+            headers.Authorization = "Bearer \${MCP_HOME_ASSISTANT_API_KEY}";
+            connect_timeout = 30;
+            timeout = 90;
+          };
+        };
+        skills.external_dirs = [ "${hermesSkills}" ];
+      };
+    };
+
+    nginx.virtualHosts = {
+      ${hermesHost} = {
+        enableACME = false;
+        useACMEHost = "wildcard.${config.domains.main}";
+        # FIXME https://github.com/NixOS/nixpkgs/issues/210807
+        acmeRoot = null;
+        forceSSL = true;
+        extraConfig = autheliaConfig.server;
+        locations."/" = {
+          proxyPass = "http://127.0.0.1:${toString dashboardPort}";
+          proxyWebsockets = true;
+          # The module appends its recommended headers after extraConfig, which
+          # would overwrite the loopback Host header Hermes requires.
+          recommendedProxySettings = false;
+          extraConfig = ''
+            ${autheliaConfig.location}
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Forwarded-Server $hostname;
+            # Hermes validates the Host header against its loopback binding.
+            proxy_set_header Host 127.0.0.1;
+            # Its WebSocket guard also validates the browser's Origin header.
+            proxy_set_header Origin http://127.0.0.1;
+          '';
+        };
+      };
+
+      # Keep ai.brkn.lol as a convenient alias without maintaining a second
+      # dashboard endpoint.
+      ${aiHost} = {
+        enableACME = false;
+        useACMEHost = "wildcard.${config.domains.main}";
+        # FIXME https://github.com/NixOS/nixpkgs/issues/210807
+        acmeRoot = null;
+        forceSSL = true;
+        locations."/".return = "308 https://${hermesHost}$request_uri";
+      };
+    };
+
+    monit.config = lib.mkAfter ''
+      check host "hermes" with address "127.0.0.1"
+        group container-services
+        restart program = "${pkgs.systemd}/bin/systemctl restart hermes-dashboard.service"
+          with timeout 180 seconds
+        if failed
+          port ${toString dashboardPort}
+          protocol http
+          request "/api/status"
+          with timeout 90 seconds
+        then restart
+        if 5 restarts within 10 cycles then alert
+    '';
+  };
+
+  # The upstream module runs the gateway natively. Its dashboard is a separate
+  # process, bound to loopback and protected by a two-factor Authelia policy.
+  systemd.services.hermes-dashboard = {
+    description = "Hermes Agent Dashboard";
+    wantedBy = [ "multi-user.target" ];
+    after = [
+      "network-online.target"
+      "hermes-agent.service"
+    ];
+    wants = [ "network-online.target" ];
+    environment = {
+      HOME = config.services.hermes-agent.stateDir;
+      HERMES_HOME = "${config.services.hermes-agent.stateDir}/.hermes";
+      HERMES_MANAGED = "true";
+    };
+    serviceConfig = {
+      User = config.services.hermes-agent.user;
+      Group = config.services.hermes-agent.group;
+      WorkingDirectory = config.services.hermes-agent.workingDirectory;
+      ExecStart = "${config.services.hermes-agent.package}/bin/hermes dashboard --host 127.0.0.1 --port ${toString dashboardPort} --no-open";
+      Restart = "always";
+      RestartSec = 5;
+      UMask = "0007";
+      NoNewPrivileges = true;
+      ProtectSystem = "strict";
+      ProtectHome = false;
+      ReadWritePaths = [
+        config.services.hermes-agent.stateDir
+        config.services.hermes-agent.workingDirectory
+      ];
+      PrivateTmp = true;
+    };
+    path = [
+      config.services.hermes-agent.package
+      pkgs.bash
+      pkgs.coreutils
+      pkgs.git
+    ];
+  };
+
+  systemd.services.hermes-agent.serviceConfig.EnvironmentFile = [
+    config.sops.templates."hermes/mcp.env".path
+  ];
+
+  # Require Authelia before proxying, including from the mesh. The dashboard
+  # itself is loopback-only, so NGINX is its only external entry point.
+  custom.authelia.extraTwoFactorDomains = [ hermesHost ];
+}

--- a/services/hermes.nix
+++ b/services/hermes.nix
@@ -11,22 +11,11 @@ let
   dashboardPort = 9119;
   autheliaConfig = import ./authelia-nginx-config.nix { inherit config; };
 
-  # Keep Hermes' skill library in the Nix store. Hermes treats external skill
-  # directories as read-only and discovers the agentskills.io-compatible
-  # SKILL.md files from this path.
-  n8nSkillsSrc = pkgs.fetchFromGitHub {
-    owner = "czlonkowski";
-    repo = "n8n-skills";
-    rev = "27e9d0ab92cccfc46db4f147497b173f214b69c5";
-    hash = "sha256-D8wEZblUGWfXKIxw3TYXhZZ0P4C1lf71cSAVgjOpmes=";
-  };
+  # Hermes treats external skill directories as read-only and discovers the
+  # agentskills.io-compatible SKILL.md files from this Nix store path.
   hermesSkills = pkgs.symlinkJoin {
     name = "hermes-skills";
-    paths = [
-      ../home-manager/devel/skills
-      "${n8nSkillsSrc}/skills"
-      pkgs.todoist-cli.skill
-    ];
+    paths = [ ./hermes/skills ];
   };
 in
 {
@@ -185,6 +174,7 @@ in
         config.services.hermes-agent.workingDirectory
       ];
       PrivateTmp = true;
+      EnvironmentFile = config.sops.templates."hermes/mcp.env".path;
     };
     path = [
       config.services.hermes-agent.package

--- a/services/hermes/skills/home-assistant/SKILL.md
+++ b/services/hermes/skills/home-assistant/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: home-assistant
+description: Use the configured Home Assistant MCP server and channel for smart-home inspection and control.
+---
+
+# Home Assistant
+
+Use the `home-assistant` MCP server for Home Assistant state queries and
+actions. Hermes also has a native Home Assistant channel for event-driven
+interaction.
+
+Query current state before making a change, then report the affected entity or
+automation and the resulting state.
+
+Safety rules:
+
+- Ask for explicit confirmation before actions that affect security, entry,
+  power, heating, network infrastructure, media playback, or any destructive
+  or irreversible operation.
+- Treat tools that run commands, restart services, update systems, or send
+  messages as high impact and require explicit confirmation before calling
+  them.
+- Never expose access tokens, secrets, or credentials in responses.
+- If Home Assistant events are needed, ask which domains or entities to watch;
+  do not enable broad event monitoring by default.

--- a/services/hermes/skills/n8n/SKILL.md
+++ b/services/hermes/skills/n8n/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: n8n
+description: Manage workflows on n8n.brkn.lol through the configured n8n MCP server.
+---
+
+# n8n
+
+Use the `n8n` MCP server for workflow discovery, inspection, validation, and
+changes. It is already authenticated to `n8n.brkn.lol`.
+
+Start by searching for a workflow and inspecting its details. Before changing
+one, explain the intended change and validate the result.
+
+Use the tools exposed by this server, such as `search_workflows`,
+`get_workflow_details`, `search_nodes`, `validate_node_config`,
+`validate_workflow`, and `create_workflow_from_code`.
+
+Safety rules:
+
+- Do not create, update, publish, unpublish, archive, restore, or execute a
+  workflow without the user's explicit confirmation.
+- Do not inspect or modify credentials unless the user explicitly requests it.
+- Prefer validation and test data before a production execution.
+- Report a workflow ID, whether it is published, and the validation outcome
+  after every change.

--- a/services/poor-tools.nix
+++ b/services/poor-tools.nix
@@ -5,8 +5,38 @@
   pkgs,
   ...
 }:
+let
+  poorInstallerWeb = pkgs.python313Packages.buildPythonPackage {
+    # The project metadata is named poor_tools_web. Using its normalized name
+    # keeps the Nixpkgs Python metadata check aligned with that metadata.
+    pname = "poor-tools-web";
+    version = "0.1.0";
+    pyproject = true;
+    src = inputs.poor-tools;
+
+    nativeBuildInputs = [
+      pkgs.python313Packages.hatchling
+      pkgs.makeWrapper
+    ];
+
+    propagatedBuildInputs = with pkgs.python313Packages; [
+      fastapi
+      uvicorn
+    ];
+
+    postInstall = ''
+      wrapProgram $out/bin/poor-installer-web \
+        --set POOR_TOOLS_VERSION ${inputs.poor-tools.shortRev or "source"}
+    '';
+
+    pythonImportsCheck = [ "poor_installer_web" ];
+  };
+in
 {
   imports = [ inputs.poor-tools.nixosModules.default ];
+
+  systemd.services.poor-installer-web.serviceConfig.ExecStart =
+    lib.mkForce "${poorInstallerWeb}/bin/poor-installer-web";
 
   services = {
     poor-installer-web.enable = true;


### PR DESCRIPTION
## Summary

- deploy Hermes Agent, dashboard, and authenticated aliases on rofl-10
- configure declarative n8n and Home Assistant MCP servers plus shared skills
- enable the native Home Assistant channel with a SOPS-managed LLAT
- add an Authelia two-factor policy for the Hermes dashboard
- make poor-tools packaging compatible with the current Python metadata check

## Validation

- nixfmt
- statix check
- deadnix
- NixOS evaluation and deployment dry-run
- deployed to rofl-10
- verified n8n MCP connectivity (34 tools), Home Assistant MCP connectivity (118 tools), and active Hermes services